### PR TITLE
fix dependency graph with for_each

### DIFF
--- a/cmd/decker/main.go
+++ b/cmd/decker/main.go
@@ -40,9 +40,9 @@ func main() {
 
 		pluginAttrs := hcl.GetPluginAttributes(block)
 
-		hclConfig, pluginContent := hcl.GetPluginContent(block, pluginHCLPath)
-
 		containsForEach := contains(pluginAttrs, "for_each")
+
+		hclConfig, pluginContent := hcl.GetPluginContent(containsForEach, block, pluginHCLPath)
 
 		if containsForEach {
 			// returns JSON, not sure why

--- a/internal/app/decker/plugins/metasploit/metasploit.hcl
+++ b/internal/app/decker/plugins/metasploit/metasploit.hcl
@@ -8,11 +8,6 @@ input "options" {
   default = {}
 }
 
-input "for_each" {
-  type = "list"
-  default = []
-}
-
 input "plugin_enabled" {
   type = "string"
   default = "true"

--- a/internal/app/decker/plugins/nmap/nmap.hcl
+++ b/internal/app/decker/plugins/nmap/nmap.hcl
@@ -5,11 +5,6 @@ input "host" {
   default = "example.com"
 }
 
-input "for_each" {
-  type = "list"
-  default = []
-}
-
 input "plugin_enabled" {
   type = "string"
   default = "true"

--- a/internal/app/decker/plugins/shell/main.go
+++ b/internal/app/decker/plugins/shell/main.go
@@ -17,10 +17,10 @@ type plugin string
 // resultsMap{
 //  "raw_output": "...",
 // }
-func (p plugin) Run(inputsMap, resultsMap *map[string]string, resultsListMap *map[string] []string) {
+func (p plugin) Run(inputsMap, resultsMap *map[string]string, resultsListMap *map[string][]string) {
 	var (
-		cmdOut    []byte
-		err       error
+		cmdOut []byte
+		err    error
 	)
 
 	cmdName := "sh"

--- a/internal/app/decker/plugins/shell/shell.hcl
+++ b/internal/app/decker/plugins/shell/shell.hcl
@@ -9,8 +9,3 @@ input "plugin_enabled" {
   type = "string"
   default = "true"
 }
-
-input "for_each" {
-  type = "list"
-  default = []
-}

--- a/internal/pkg/hcl/resources.go
+++ b/internal/pkg/hcl/resources.go
@@ -29,20 +29,6 @@ func GetExprVars(block *hcl.Block) map[string][]hcl.Traversal {
 
 	for attr := range content.Attributes {
 		exprVars[attr] = content.Attributes[attr].Expr.Variables()
-
-		// support for_each by deleting "each" line from the exprVars
-		// otherwise this will cause "panic: simple: adding self edge"
-		// in graph.go - addEdgesToGraph
-		for _, contentVars := range exprVars[attr] {
-			rootName := contentVars.RootName()
-
-			// this might delete a full expr causing a bug if the line is something
-			// like: "${each.key} ${some_module.key}" where "some_module.key" also
-			// gets deleted?
-			if rootName == "each" {
-				delete(exprVars, attr)
-			}
-		}
 	}
 
 	return exprVars


### PR DESCRIPTION
Fixes issue where `for_each` had to be specified by a plugin's HCL when loops were used, fixes issue where dependency graph was ignoring `for_each` and plugin's sometimes ran out of order.