### PR TITLE
support default string values for plugin inputs

### DIFF
--- a/internal/pkg/hcl/hcl_decoder.go
+++ b/internal/pkg/hcl/hcl_decoder.go
@@ -3,6 +3,7 @@ package hcl
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 
 	"github.com/hashicorp/hcl2/gohcl"
@@ -33,7 +34,7 @@ func DecodeHCLResourceBlock(block *hcl.Block, runningVals *map[string]*map[strin
 // DecodeHCLAttribute calls BuildEvalContext() with the plugin results aggregated from each
 // iterative run and attempts to decode a Block's Attribute's Expression
 // using the context
-func DecodeHCLAttribute(attribute *hcl.Attribute, runningVals *map[string]*map[string]cty.Value) string {
+func DecodeHCLAttribute(attribute *hcl.Attribute, runningVals *map[string]*map[string]cty.Value, defVal string) string {
 	// will return evalcontext with environment variables
 	ctx := BuildEvalContext(runningVals)
 
@@ -46,7 +47,12 @@ func DecodeHCLAttribute(attribute *hcl.Attribute, runningVals *map[string]*map[s
 	if err != nil {
 		boolErr := gocty.FromCtyValue(ctyVal, &decodedBool)
 		if boolErr != nil {
-			fmt.Println("Decoding error for string and bool:", boolErr)
+			if defVal != "" {
+				decodedVal = defVal
+			} else {
+				fmt.Println("Decoding error for string and bool and default value was an empty string:", boolErr)
+				os.Exit(1)
+			}
 		} else {
 			decodedVal = strconv.FormatBool(decodedBool)
 		}

--- a/internal/pkg/hcl/plugins.go
+++ b/internal/pkg/hcl/plugins.go
@@ -136,7 +136,7 @@ func CreateInputsMap(inputs []PluginInputConfig, attributes hcl.Attributes, eval
 	// pass in default in case parsing fails
 	for key, attribute := range attributes {
 		inputType := hclInputs[key].Type
-		// inputDefault := hclInputs[key].Default
+		inputDefault := hclInputs[key].Default
 
 		if key != "for_each" {
 			if inputType == "list" {
@@ -145,7 +145,7 @@ func CreateInputsMap(inputs []PluginInputConfig, attributes hcl.Attributes, eval
 				inputsMap[key] = DecodeHCLMapAttribute(attribute, evalVals)
 			} else {
 				// strings and booleans
-				inputsMap[key] = DecodeHCLAttribute(attribute, evalVals)
+				inputsMap[key] = DecodeHCLAttribute(attribute, evalVals, inputDefault)
 			}
 		}
 	}


### PR DESCRIPTION
Defaults to string value set in plugin's HCL, exits program if string fails to decode and default is not set (avoiding run-time panic)