### PR TITLE
validate config file against unknown plugins and duplicate resources

### DIFF
--- a/cmd/decker/main.go
+++ b/cmd/decker/main.go
@@ -29,6 +29,9 @@ func main() {
 	hclConfigFile := paths.GetConfigFilePath()
 
 	blocks := hcl.GetBlocksFromConfig(hclConfigFile)
+
+	dependencies.ValidateConfig(blocks)
+
 	varBlockNames := dependencies.GetVariableNames(blocks)
 	resBlocksSorted := dependencies.Sort(blocks)
 

--- a/internal/pkg/dependencies/config.go
+++ b/internal/pkg/dependencies/config.go
@@ -1,0 +1,52 @@
+package dependencies
+
+import (
+	"fmt"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/stevenaldinger/decker/internal/pkg/plugins"
+	"os"
+)
+
+// ValidateConfig checks the given config for some common errors and exits with
+// error messages and how to fix the issues.
+func ValidateConfig(blocks []*hcl.Block) {
+	availablePlugins := plugins.AvailablePlugins()
+
+	pluginNames := []string{}
+	invalidPluginNames := []string{}
+	resourceNames := []string{}
+	duplicateResourceNames := []string{}
+
+	for _, block := range blocks {
+		switch block.Type {
+		case "resource":
+			resourcePlugin, resourceName := block.Labels[0], block.Labels[1]
+			validPlugin := contains(availablePlugins, resourcePlugin)
+			if validPlugin {
+				pluginNames = append(pluginNames, resourcePlugin)
+			} else {
+				invalidPluginNames = append(invalidPluginNames, resourcePlugin)
+			}
+
+			duplicateResourceName := contains(resourceNames, resourceName)
+			if duplicateResourceName {
+				duplicateResourceNames = append(duplicateResourceNames, resourceName)
+			} else {
+				resourceNames = append(resourceNames, resourceName)
+			}
+		}
+	}
+
+	if len(invalidPluginNames) != 0 {
+		fmt.Println("[ERROR]: Invalid plugin names were referenced in your config. The following plugins could not be found by decker:", invalidPluginNames)
+	}
+
+	if len(duplicateResourceNames) != 0 {
+		fmt.Println("[ERROR]: Duplicate resource names were found in your config. The following resource names were used more than once:", duplicateResourceNames)
+		fmt.Println("[ERROR]: Please give each resource a unique name and try again.")
+	}
+
+	if len(invalidPluginNames) != 0 || len(duplicateResourceNames) != 0 {
+		os.Exit(1)
+	}
+}

--- a/internal/pkg/paths/plugins.go
+++ b/internal/pkg/paths/plugins.go
@@ -10,3 +10,12 @@ func GetPluginHCLFilePath(pluginName string) string {
 
 	return filePath
 }
+
+// GetPluginDirectory gets the directory decker searches for plugins.
+func GetPluginDirectory() string {
+	deckerDir := GetDeckerDir()
+
+	pluginDir := deckerDir + "/internal/app/decker/plugins"
+
+	return pluginDir
+}

--- a/internal/pkg/plugins/available_plugins.go
+++ b/internal/pkg/plugins/available_plugins.go
@@ -1,0 +1,28 @@
+package plugins
+
+import (
+	"io/ioutil"
+	"log"
+
+	"github.com/stevenaldinger/decker/internal/pkg/paths"
+)
+
+// AvailablePlugins searches the plugin directory and returns names of each
+// plugin found.
+func AvailablePlugins() []string {
+	pluginDir := paths.GetPluginDirectory()
+	files, err := ioutil.ReadDir(pluginDir)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var plugins = []string{}
+
+	for _, f := range files {
+		if f.IsDir() {
+			plugins = append(plugins, f.Name())
+		}
+	}
+
+	return plugins
+}


### PR DESCRIPTION
Duplicate resource names will cause errors when establishing topology and unknown plugin names should keep the config from running (with a nice error message) too before it causes other issues.